### PR TITLE
Update _arcade-organizer.sh in order to avoid symlinks creation

### DIFF
--- a/_arcade-organizer.sh
+++ b/_arcade-organizer.sh
@@ -125,6 +125,7 @@ def make_config():
     config['VERBOSE'] = ini_parser.get_bool('VERBOSE', False)
     config['AZ_DIR'] = ini_parser.get_bool('AZ_DIR', True)
     config['ARCADE_OFFSET_DIRECTORY'] = "%s_Arcade Offset" % config['MRADIR']
+    config['NO_SYMLINKS'] = ini_parser.get_bool('NO_SYMLINKS', False)
 
     config['REGION_MAIN'] = ini_parser.get_string('REGION_MAIN', 'DEV PREFERRED')
     config['REGION_OTHERS'] = ini_parser.get_bool_flag_presence('REGION_OTHERS', BoolFlagPresence.ONLY_IN_OWN_FOLDER)
@@ -346,7 +347,11 @@ class Infrastructure:
         if self._config['PRINT_SYMLINKS']:
             self._printer.print("make_symlink: src %s dst %s" % (src, dst))
         else:
-            os.symlink(src, dst)
+            if self._config['NO_SYMLINKS']:
+                shutil.copy(src, dst)
+            else:
+                os.symlink(src, dst)
+		
 
     def download_mad_db_zip(self):
         self._printer.print("Downloading Mister Arcade Descriptions database")


### PR DESCRIPTION
Option to no create symlinks in order to work for cifs mount. With that you can also mount _Arcade directory.
I had problems trying to run the actual arcade_organizer because it failed when trying to create symlinks on cifs mounted.
It multiplies used hard drive space because it duplicates every mra on every directory it has to be placed on _Organized, but it works for cifs mounted dirs on a NAS, and NAS units use to have plenty of hard drive space.
It needs a new option called NO_SYMLINKS = true.