### PR TITLE
Update _arcade-organizer.sh

### DIFF
--- a/_arcade-organizer.sh
+++ b/_arcade-organizer.sh
@@ -955,7 +955,7 @@ class ArcadeOrganizer:
         self.impl_create_array_links('PLATFORM_DIR', 'platform', 'ORGDIR_Platform')
 
     def create_players(self):
-        self.impl_create_array_links('PLAYERS_DIR', 'players', 'ORGDIR_Players')
+        self.impl_create_single_link('PLAYERS_DIR', 'players', 'ORGDIR_Players')
 
     def create_move_inputs(self):
         self.impl_create_array_links('MOVE_INPUTS_DIR', 'move_inputs', 'ORGDIR_MoveInputs')

--- a/_arcade-organizer.sh
+++ b/_arcade-organizer.sh
@@ -955,7 +955,7 @@ class ArcadeOrganizer:
         self.impl_create_array_links('PLATFORM_DIR', 'platform', 'ORGDIR_Platform')
 
     def create_players(self):
-        self.impl_create_single_link('PLAYERS_DIR', 'players', 'ORGDIR_Players')
+        self.impl_create_array_links('PLAYERS_DIR', 'players', 'ORGDIR_Players')
 
     def create_move_inputs(self):
         self.impl_create_array_links('MOVE_INPUTS_DIR', 'move_inputs', 'ORGDIR_MoveInputs')

--- a/_arcade-organizer.sh
+++ b/_arcade-organizer.sh
@@ -874,6 +874,8 @@ class ArcadeOrganizer:
 
     def impl_create_array_links(self, config_dir_check, description_field, orgdir):
         if self._config[config_dir_check]:
+            if not isinstance(self._description[description_field], list):
+                self._description[description_field] = [self._description[description_field]]
             for entry in self._description[description_field]:
                 self.create_symlink("%s/_%s/" % (self._config[orgdir], entry))
 


### PR DESCRIPTION
When processing array links in impl_create_array_links method, if the database contains a single value for that category, it will be treated as an array with one single value.